### PR TITLE
Add docs for task settings and execution output

### DIFF
--- a/artisan-commands.md
+++ b/artisan-commands.md
@@ -14,6 +14,8 @@ This command will also create a random signing key and add it to your `.env` fil
 Once setup is complete, you will receive an email to verify that your application's tasks are ready to be monitored. Each of your tasks will remain in a pending state until they are triggered by your scheduler for the first time.
 
 > Any tasks that are defined using the `environments()` constraint will only be detected in that environment.
+>
+> Any tasks that have been [configured](/docs/configuration#skipping-tasks) to be skipped will not be sent as part of the setup task payload.
 
 ## `thenpingme:sync`
 
@@ -27,7 +29,9 @@ In order for all relevant tasks to be monitored, this command should be run in t
 
 That is to say, if you have tasks constrained to only run in production environments &ndash; `environments(['production'])` &ndash; you should run `thenpingme:sync` *in* the production environment.
 
-**Note**: This command will always run in sync, so you receive immediate feedback if your tasks fail to sync for any reason.
+> **Note**: This command will always run in sync, so you receive immediate feedback if your tasks fail to sync for any reason.
+>
+> Any tasks that have been [configured](/docs/configuration#skipping-tasks) to be skipped will not be sent as part of the sync task payload. Tasks that were previously monitored will be removed from thenping.me.
 
 ## `thenpingme:schedule` <dl class="ml-3 mt-1.5 align-top inline-flex items-center px-3 py-1 rounded-full text-sm font-medium leading-4 bg-indigo-100 text-indigo-900 tracking-tight"><dt class="sr-only">Tailwind CSS version</dt><dd>< v3.2</dd></dl>
 

--- a/artisan-commands.md
+++ b/artisan-commands.md
@@ -29,7 +29,13 @@ That is to say, if you have tasks constrained to only run in production environm
 
 **Note**: This command will always run in sync, so you receive immediate feedback if your tasks fail to sync for any reason.
 
-## `thenpingme:schedule`
+## `thenpingme:schedule` <dl class="ml-3 mt-1.5 align-top inline-flex items-center px-3 py-1 rounded-full text-sm font-medium leading-4 bg-indigo-100 text-indigo-900 tracking-tight"><dt class="sr-only">Tailwind CSS version</dt><dd>< v3.2</dd></dl>
+
+<div class="p-4 shadow sm:rounded-md bg-blue-50">
+    <span class="text-md text-blue-700">
+        <b>Note</b>: With the introduction of the new <code>artisan schedule:list</code> command in Laravel 9.x, the functionality provided by this package has been deprecated and will be removed in a later version.
+    </span>
+</div>
 
 The `schedule` command is useful to get a quick overview of all of your application's scheduled tasks, their interval, expected previous and next runs.
 

--- a/configuration.md
+++ b/configuration.md
@@ -103,7 +103,10 @@ return [
 ]
 ```
 
-In addition, if there are any tasks you do not wish to monitor at all, you may use the `skip` configuration option.
+<a name="skipping-tasks"></a>
+### Skipping tasks <dl class="ml-3 mt-1.5 align-top inline-flex items-center px-3 py-1 rounded-full text-sm font-medium leading-4 bg-indigo-100 text-indigo-900 tracking-tight"><dt class="sr-only">Tailwind CSS version</dt><dd>v3.1+</dd></dl>
+
+If there are any tasks you do not wish to monitor at all, you may use the `skip` configuration option.
 
 When skipped, the task will not be sent as part of the `thenpingme:setup` or `thenpingme:sync` commands, nor will it appear in the `thenpingme:schedule` or `thenpingme:verify` output.
 

--- a/configuration.md
+++ b/configuration.md
@@ -5,6 +5,12 @@ thenping.me aims to be a zero-configuration tool for monitoring your application
 
 ## Environment variables
 
+### `THENPINGME_ENABLED`
+
+If you need to disable sending pings, for example staging or development environments, you may set this value to `false` in your environment to prevent pings being dispatched. 
+
+Note that we will still expect your application to ping at configured intervals, so ensure you have at least one active environment sending pings to avoid false-positive alerts. 
+
 ### `THENPINGME_PROJECT_ID`
 
 Identifies your application to thenping.me when it sends its ping payloads. This is automatically set when you run the [`thenpingme:setup`](/docs/installation) command for the first time.

--- a/configuration.md
+++ b/configuration.md
@@ -1,8 +1,9 @@
 ---
 title: Configuration
 ---
-thenping.me aims to be a zero-configuration tool for monitoring your application's scheduled tasks, however, does allow you to configure certain aspects using environment variables.
+thenping.me aims to be a zero-configuration tool for starting to monitor your application's scheduled tasks. It does, however, allow you to configure certain aspects using either [environment variables](#environment-variables) or [task-specific configuration](#task-configuration).
 
+<a name="environment-variables"></a>
 ## Environment variables
 
 ### `THENPINGME_ENABLED`
@@ -53,14 +54,14 @@ php artisan vendor:publish --tag=thenpingme-config
 
 This will publish the configuration to `config/thenpingme.php`.
 
-The most common configuration you will make in this file will be setting of the `release` value, if you would like to track your application release/version along with your pings.
+The most common configuration you will make in this file will be setting of the `release` value, if you would like to [track your application release/version](/docs/faq#track-releases-with-tasks) along with your pings.
 
+<a name="task-configuration"></a>
+## Task configuration <dl class="ml-3 mt-1.5 align-top inline-flex items-center px-3 py-1 rounded-full text-sm font-medium leading-4 bg-indigo-100 text-indigo-900 tracking-tight"><dt class="sr-only">Tailwind CSS version</dt><dd>v3.0+</dd></dl>
 
-## Task configuration
+Settings may be configured on a per-task basis directly within your scheduled task configuration in your application code.
 
-As of version [3.0.0](https://github.com/thenpingme/thenpingme-laravel/releases/tag/3.0.0) of the client package, task settings can be made configured on a per-task basis directly within your scheduled task.
-
-This allows you to have control of how your tasks are monitored right alongside where you define the task schedule.
+This puts you in control of how your tasks are monitored right alongside where you define the task schedule.
 
 ```php
 // app/Console/Kernel.php
@@ -78,9 +79,13 @@ protected function schedule(Schedule $schedule)
 }
 ```
 
-Relatedly, from version [3.1.0](https://github.com/thenpingme/thenpingme-laravel/releases/tag/3.1.0) of the client package, you may configure project-wide setting defaults.
+### Project defaults <dl class="ml-3 mt-1.5 align-top inline-flex items-center px-3 py-1 rounded-full text-sm font-medium leading-4 bg-indigo-100 text-indigo-900 tracking-tight"><dt class="sr-only">Tailwind CSS version</dt><dd>v3.1+</dd></dl>
 
-These values, when set, will be the default for all tasks in your project and take precedence over the default values used by thenping.me. Any tasks-specific settings will override the project defaults.
+Relatedly, you may also configure project-wide setting defaults directly within your application.
+
+These values, when set, will be the default for all tasks in your project and take precedence over the default values used by thenping.me.
+
+Task-specific settings will take precedence over any project defaults.
 
 ```php
 // config/thenpingme.php
@@ -98,7 +103,9 @@ return [
 ]
 ```
 
-In addition (from ^3.1), if there are any tasks you do not wish to monitor at all, you may use the `skip` configuration option. When skipped, the task will not be sent as part of the `thenpingme:setup` or `thenpingme:sync` commands, nor will it appear in the `thenpingme:schedule` or `thenpingme:verify` output.
+In addition, if there are any tasks you do not wish to monitor at all, you may use the `skip` configuration option.
+
+When skipped, the task will not be sent as part of the `thenpingme:setup` or `thenpingme:sync` commands, nor will it appear in the `thenpingme:schedule` or `thenpingme:verify` output.
 
 ```php
 // app/Console/Kernel.php
@@ -115,13 +122,19 @@ protected function schedule(Schedule $schedule)
 ```
 
 <a name="output-logging"></a>
-### Output logging
+### Output logging <dl class="ml-3 mt-1.5 align-top inline-flex items-center px-3 py-1 rounded-full text-sm font-medium leading-4 bg-indigo-100 text-indigo-900 tracking-tight"><dt class="sr-only">Tailwind CSS version</dt><dd>v3.2+</dd></dl>
 
-From version [3.2.0](https://github.com/thenpingme/thenpingme-laravel/releases/tag/3.2.0) of the client package, and on supported plans, you may enable output capturing.
+<div class="p-4 shadow sm:rounded-md bg-blue-50">
+    <span class="text-md text-blue-700">
+        <b>Note</b>: Output logging may only be configured in your application's task schedule as command output is pushed to thenping.me.
+    </span>
+</div>
 
-Of course, this is useful for monitoring the output of your scheduled tasks in general, but can be configured to capture output only on failure. When a task failure raises an alert, the output will be included with the alert notification giving you clear context surrounding the task failure.
+On [supported plans](https://thenping.me/#pricing), you may enable output logging on a per-task basis.
 
-There are three options for controlling when output is stored.
+Of course, this is useful for monitoring the output of your scheduled tasks in general, but can be configured to capture output only on failure. 
+
+When a task failure raises an alert, the output will be included with the alert notification giving you clear context surrounding the task failure.
 
 | Configuration Level      | Description                     |
 | :----------------------- | :------------------------------ |
@@ -148,7 +161,7 @@ protected function schedule(Schedule $schedule)
 **Note**: Whilst you may configure tasks to send output at any time, only plans that [support output logging](/#pricing) will display the output and include it in alert notifications.
 
 <a name="conditional-output-logging"></a>
-### Conditional output logging
+### Conditional output logging <dl class="ml-3 mt-1.5 align-top inline-flex items-center px-3 py-1 rounded-full text-sm font-medium leading-4 bg-indigo-100 text-indigo-900 tracking-tight"><dt class="sr-only">Tailwind CSS version</dt><dd>v3.2+</dd></dl>
 
 By leveraging [bitwise operations](https://www.php.net/manual/en/language.operators.bitwise.php), you may choose to log task output only when it is present. 
 

--- a/configuration.md
+++ b/configuration.md
@@ -113,3 +113,60 @@ protected function schedule(Schedule $schedule)
         );
 }
 ```
+
+<a name="output-logging"></a>
+### Output logging
+
+From version [3.2.0](https://github.com/thenpingme/thenpingme-laravel/releases/tag/3.2.0) of the client package, and on supported plans, you may enable output capturing.
+
+Of course, this is useful for monitoring the output of your scheduled tasks in general, but can be configured to capture output only on failure. When a task failure raises an alert, the output will be included with the alert notification giving you clear context surrounding the task failure.
+
+There are three options for controlling when output is stored.
+
+| Configuration Level      | Description                     |
+| :----------------------- | :------------------------------ |
+| `Thenpingme::STORE_OUTPUT` | Store all scheduled task output |
+| `Thenpingme::STORE_OUTPUT_ON_SUCCESS` | Store scheduled task output only on successful task finish or skip |
+| `Thenpingme::STORE_OUTPUT_ON_FAILURE` | Store scheduled task output only on non-zero exit code, or scheduled task failure |
+| `Thenpingme::STORE_OUTPUT_IF_PRESENT` | When used <a href="#conditional-output-logging">in combination with</a> the any of the above options, output is logged only when it is not empty |
+
+```php
+// app/Console/Kernel.php
+use Thenpingme\Thenpingme;
+
+protected function schedule(Schedule $schedule)
+{
+    $schedule
+        ->command(SomeCommandThatShouldNotBeMonitored::class)
+        ->hourly()
+        ->thenpingme(
+            output: Thenpingme::STORE_OUTPUT,
+        );
+}
+```
+
+**Note**: Whilst you may configure tasks to send output at any time, only plans that [support output logging](/#pricing) will display the output and include it in alert notifications.
+
+<a name="conditional-output-logging"></a>
+### Conditional output logging
+
+By leveraging [bitwise operations](https://www.php.net/manual/en/language.operators.bitwise.php), you may choose to log task output only when it is present. 
+
+This is useful in times when you have a known-failure scenario that produces a non-zero exit code but does not render any output. 
+
+Receiving blank task output in this scenario may lead to confusing debugging scenarios.
+
+```php
+// app/Console/Kernel.php
+use Thenpingme\Thenpingme;
+
+protected function schedule(Schedule $schedule)
+{
+    $schedule
+        ->command(CommandThatSometimesOutputs::class)
+        ->hourly()
+        ->thenpingme(
+            output: Thenpingme::STORE_OUTPUT | Thenpingme::STORE_OUTPUT_IF_PRESENT,
+        );
+}
+```

--- a/executions.md
+++ b/executions.md
@@ -18,53 +18,45 @@ Tasks that are scheduled in your `app/Console/Kernel.php` using `when()` or `unl
 An execution can exist in one of five statuses:
 
 <div class="w-full overflow-hidden bg-white rounded-md shadow-md divide-y">
-    <div class="flex w-full p-4">
-        <div class="w-16 sm:w-20 flex-justify-center">
+    <div class="grid grid-cols-6 gap-4 p-3">
+        <div class="col-span-1 flex items-start">
             <div>
                 <span class="inline-flex px-2 text-xs font-semibold text-blue-800 bg-blue-100 rounded-full leading-5">Running</span>
             </div>
         </div>
-        <div class="ml-2 w-5/6">
+        <div class="col-span-5">
             We have received a start ping, indicating that the execution is currently in progress.
         </div>
-    </div>
-    <div class="flex w-full p-4">
-        <div class="w-16 sm:w-20 flex-justify-center">
+        <div class="col-span-1 flex items-start">
             <div>
                 <span class="inline-flex px-2 text-xs font-semibold text-green-800 bg-green-100 rounded-full leading-5">Finished</span>
             </div>
         </div>
-        <div class="ml-2 w-5/6">
+        <div class="col-span-5">
             We received a finish ping, indicating that the execution completed without failure.
         </div>
-    </div>
-    <div class="flex w-full p-4">
-        <div class="w-16 sm:w-20 flex-justify-center">
+        <div class="col-span-1 flex items-start">
             <div>
                 <span class="inline-flex px-2 text-xs font-semibold text-purple-800 bg-purple-100 rounded-full leading-5">Skipped</span>
             </div>
         </div>
-        <div class="ml-2 w-5/6">
+        <div class="col-span-5">
             We received a skipped ping, indicating that your task was evaluated for execution but did not run based on the result of a truth test constraint in your scheduler.
         </div>
-    </div>
-    <div class="flex w-full p-4">
-        <div class="w-16 sm:w-20 flex-justify-center">
+        <div class="col-span-1 flex items-start">
             <div>
                 <span class="inline-flex px-2 text-xs font-semibold text-red-800 bg-red-100 rounded-full leading-5">Timedout</span>
             </div>
         </div>
-        <div class="ml-2 w-5/6">
+        <div class="col-span-5">
             A finish ping was either not received, or the finish ping was not received within the allowed runtime. Note that an execution that reached the timedout status is not final. For a long-running task, the finish ping may arrive later.
         </div>
-    </div>
-    <div class="flex w-full p-4">
-        <div class="w-16 sm:w-20 flex-justify-center">
+        <div class="col-span-1 flex items-start">
             <div>
                 <span class="inline-flex px-2 text-xs font-semibold text-red-800 bg-red-100 rounded-full leading-5">Failed</span>
             </div>
         </div>
-        <div class="ml-2 w-5/6">
+        <div class="col-span-5">
             An exception was thrown during execution of your task.
         </div>
     </div>

--- a/faq.md
+++ b/faq.md
@@ -86,6 +86,7 @@ If you have a task that only runs in production, but you ran the [`thenpingme:se
 
 Always make sure you run the `thenpingme:sync` command from the environment you are monitoring wherever possible.
 
+<a name="track-releases-with-tasks"></a>
 ## How can I track releases with my tasks?
 You can [configure](/docs/configuration) your application to send the release to us on each ping using the `thenpingme.release` key.
 

--- a/tasks.md
+++ b/tasks.md
@@ -59,58 +59,50 @@ For example, if you were to configure a consecutive failure threshold of 3, we w
 For each task, there are a series of icons that identify different components of its configuration.
 
 <div class="w-full overflow-hidden bg-white rounded-md shadow-md divide-y">
-    <div class="flex w-full p-4">
-        <div class="w-16 sm:w-20 flex justify-center">
+    <div class="grid grid-cols-6 gap-4 p-3">
+        <div class="col-span-1 flex items-start justify-center mt-1">
             <svg class="w-6 h-6 text-indigo-300" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
                 <path d="M7 9a2 2 0 012-2h6a2 2 0 012 2v6a2 2 0 01-2 2H9a2 2 0 01-2-2V9z"></path>
                 <path d="M5 3a2 2 0 00-2 2v6a2 2 0 002 2V5h8a2 2 0 00-2-2H5z"></path>
             </svg>
         </div>
-        <div class="ml-2 w-5/6 flex flex-col">
+        <div class="col-span-5 flex flex-col">
             <span class="font-medium">May overlap</span>
             <span class="text-gray-600 text-sm">Should this task run longer than it's configured interval, it is possible that it can be running multiple times simultaneously.</span>
         </div>
-    </div>
-    <div class="flex w-full p-4">
-        <div class="w-16 sm:w-20 flex justify-center">
+        <div class="col-span-1 flex items-start justify-center mt-1">
             <svg class="w-6 h-6 text-indigo-300" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
                 <path fill-rule="evenodd" d="M9 3a1 1 0 012 0v5.5a.5.5 0 001 0V4a1 1 0 112 0v4.5a.5.5 0 001 0V6a1 1 0 112 0v5a7 7 0 11-14 0V9a1 1 0 012 0v2.5a.5.5 0 001 0V4a1 1 0 012 0v4.5a.5.5 0 001 0V3z" clip-rule="evenodd"></path>
             </svg>
         </div>
-        <div class="ml-2 w-5/6 flex flex-col">
+        <div class="col-span-5 flex flex-col">
             <span class="font-medium">Not in maintenance mode</span>
             <span class="text-gray-600 text-sm">This task will not run if you have run <code>artisan down</code> in your application.</span>
         </div>
-    </div>
-    <div class="flex w-full p-4">
-        <div class="w-16 sm:w-20 flex justify-center">
+        <div class="col-span-1 flex items-start justify-center mt-1">
             <svg class="w-6 h-6 text-indigo-300" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
                 <path fill-rule="evenodd" d="M3 5a2 2 0 012-2h10a2 2 0 012 2v8a2 2 0 01-2 2h-2.22l.123.489.804.804A1 1 0 0113 18H7a1 1 0 01-.707-1.707l.804-.804L7.22 15H5a2 2 0 01-2-2V5zm5.771 7H5V5h10v7H8.771z" clip-rule="evenodd"></path>
             </svg>
         </div>
-        <div class="ml-2 w-5/6 flex flex-col">
+        <div class="col-span-5 flex flex-col">
             <span class="font-medium">On one server</span>
             <span class="text-gray-600 text-sm">This task has been configured to run on one server only.</span>
         </div>
-    </div>
-    <div class="flex w-full p-4">
-        <div class="w-16 sm:w-20 flex justify-center">
+        <div class="col-span-1 flex items-start justify-center mt-1">
             <svg class="w-6 h-6 text-indigo-300" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
                 <path d="M7 3a1 1 0 000 2h6a1 1 0 100-2H7zM4 7a1 1 0 011-1h10a1 1 0 110 2H5a1 1 0 01-1-1zM2 11a2 2 0 012-2h12a2 2 0 012 2v4a2 2 0 01-2 2H4a2 2 0 01-2-2v-4z"></path>
             </svg>
         </div>
-        <div class="ml-2 w-5/6 flex flex-col">
+        <div class="col-span-5 flex flex-col">
             <span class="font-medium">Runs in background</span>
             <span class="text-gray-600 text-sm">This task has been configured to run in the background, so it will not delay the start of other tasks on the same execution schedule.</span>
         </div>
-    </div>
-    <div class="flex w-full p-4">
-        <div class="w-16 sm:w-20 flex justify-center">
+        <div class="col-span-1 flex items-start justify-center mt-1">
             <svg class="w-6 h-6 text-indigo-300" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
                 <path fill-rule="evenodd" d="M3 3a1 1 0 011-1h12a1 1 0 011 1v3a1 1 0 01-.293.707L12 11.414V15a1 1 0 01-.293.707l-2 2A1 1 0 018 17v-5.586L3.293 6.707A1 1 0 013 6V3z" clip-rule="evenodd"></path>
             </svg>
         </div>
-        <div class="ml-2 w-5/6 flex flex-col">
+        <div class="col-span-5 flex flex-col">
             <span class="font-medium">Task is filtered</span>
             <span class="text-gray-600 text-sm">This task may be skipped, subject to the result of a <a href="https://laravel.com/docs/8.x/scheduling#truth-test-constraints" target="_blank">truth-test constraint</a> at runtime.</span>
         </div>
@@ -122,63 +114,41 @@ For each task, there are a series of icons that identify different components of
 A task can exist in one of six states:
 
 <div class="w-full overflow-hidden bg-white rounded-md shadow-md divide-y">
-    <div class="flex w-full p-4">
-        <div class="w-16 sm:w-20 flex justify-center">
-            <div>
-                <span class="inline-flex px-2 text-xs font-semibold text-gray-800 bg-gray-100 rounded-full leading-5">Pending</span>
-            </div>
+    <div class="grid grid-cols-6 gap-4 p-3">
+        <div class="col-span-1 flex items-start mt-1">
+            <span class="inline-flex px-2 text-xs font-semibold text-gray-800 bg-gray-100 rounded-full leading-5">Pending</span>
         </div>
-        <div class="ml-2 w-5/6">
+        <div class="col-span-5">
             We are waiting for your task to ping for the first time.
         </div>
-    </div>
-    <div class="flex w-full p-4">
-        <div class="w-16 sm:w-20 flex justify-center">
-            <div>
-                <span class="inline-flex px-2 text-xs font-semibold text-blue-800 bg-blue-100 rounded-full leading-5">Running</span>
-            </div>
+        <div class="col-span-1 flex items-start mt-1">
+            <span class="inline-flex px-2 text-xs font-semibold text-blue-800 bg-blue-100 rounded-full leading-5">Running</span>
         </div>
-        <div class="ml-2 w-5/6">
+        <div class="col-span-5">
             We have received a start ping, indicating that your task is currently running.
         </div>
-    </div>
-    <div class="flex w-full p-4">
-        <div class="w-16 sm:w-20 flex justify-center">
-            <div>
-                <span class="inline-flex px-2 text-xs font-semibold text-green-800 bg-green-100 rounded-full leading-5">Passing</span>
-            </div>
+        <div class="col-span-1 flex items-start mt-1">
+            <span class="inline-flex px-2 text-xs font-semibold text-green-800 bg-green-100 rounded-full leading-5">Passing</span>
         </div>
-        <div class="ml-2 w-5/6">
+        <div class="col-span-5">
             Your task is currently running on schedule.
         </div>
-    </div>
-    <div class="flex w-full p-4">
-        <div class="w-16 sm:w-20 flex justify-center">
-            <div>
-                <span class="inline-flex px-2 text-xs font-semibold text-red-800 bg-red-100 rounded-full leading-5">Missing</span>
-            </div>
+        <div class="col-span-1 flex items-start mt-1">
+            <span class="inline-flex px-2 text-xs font-semibold text-red-800 bg-red-100 rounded-full leading-5">Missing</span>
         </div>
-        <div class="ml-2 w-5/6">
+        <div class="col-span-5">
             Your task was expected to send a start ping, but it has not been received within the allowed grace period.
         </div>
-    </div>
-    <div class="flex w-full p-4">
-        <div class="w-16 sm:w-20 flex justify-center">
-            <div>
-                <span class="inline-flex px-2 text-xs font-semibold text-red-800 bg-red-100 rounded-full leading-5">Failed</span>
-            </div>
+        <div class="col-span-1 flex items-start mt-1">
+            <span class="inline-flex px-2 text-xs font-semibold text-red-800 bg-red-100 rounded-full leading-5">Failed</span>
         </div>
-        <div class="ml-2 w-5/6">
+        <div class="col-span-5">
             We received a start ping on schedule, however, your task threw an exception and reported that it had failed.
         </div>
-    </div>
-    <div class="flex w-full p-4">
-        <div class="w-16 sm:w-20 flex justify-center">
-            <div>
-                <span class="inline-flex px-2 text-xs font-semibold text-orange-800 bg-orange-100 rounded-full leading-5">Failing</span>
-            </div>
+        <div class="col-span-1 flex items-start mt-1">
+            <span class="inline-flex px-2 text-xs font-semibold text-orange-800 bg-orange-100 rounded-full leading-5">Failing</span>
         </div>
-        <div class="ml-2 w-5/6">
+        <div class="col-span-5">
             We received a start ping on schedule, however, your task has not sent the finish ping within the runtime allowance.
         </div>
     </div>


### PR DESCRIPTION
Adds documentation for features added by thenpingme/thenpingme-laravel#18, thenpingme/thenpingme-laravel#25, thenpingme/thenpingme-laravel#33, and thenpingme/thenpingme-laravel#34

Also adds some structural and style improvements.
